### PR TITLE
GitHub Actionsでリリースを自動化

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,79 @@
+name: release binary
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  build-client:
+    name: Build-Client
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: yarn install, and build
+        run: |
+          cd client
+          yarn install
+          yarn build:stage
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: client
+          path: client/dist
+
+  build-server:
+    name: Build-server
+    runs-on: ubuntu-latest
+    needs: build-client
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Download Client artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: client
+          path: client/dist
+      - name: Get dependencies
+        env:
+          GO111MODULE: on
+          GOPATH: /home/runner/work/
+        run: |
+          go get github.com/rakyll/statik
+          cd server
+          $GOPATH/bin/statik --src ../client/dist
+      - name: upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: server
+          path: server
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      - name: Download Client artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: server
+          path: server
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: latest
+          args: release --rm-dist
+          key: ${{ secrets.YOUR_PRIVATE_KEY }}
+          workdir: server


### PR DESCRIPTION
close  #65

tagが打たれたタイミングで`Ubuntu, Mac`向けにビルドしてリリースする